### PR TITLE
fix: extractor should be initialized before self.load in Application

### DIFF
--- a/rag.py
+++ b/rag.py
@@ -286,6 +286,9 @@ class Application:
         Creates a new application.
         """
 
+        # Textractor instance (lazy loaded)
+        self.textractor = None
+
         # Load LLM
         self.llm = LLM(
             os.environ.get(
@@ -318,9 +321,6 @@ context: {context} """
             template=template,
             context=self.context,
         )
-
-        # Textractor instance (lazy loaded)
-        self.textractor = None
 
     def load(self):
         """


### PR DESCRIPTION
In the `Application.__init__`, `self.load` can result in calling `extract` which will throw as `self.extractor` haven't been set